### PR TITLE
LoggedCommand must extends Cake\Database\Log\LoggedQuery

### DIFF
--- a/src/LoggedCommand.php
+++ b/src/LoggedCommand.php
@@ -2,7 +2,9 @@
 
 namespace Cake\Redis;
 
-class LoggedCommand {
+use Cake\Database\Log\LoggedQuery;
+
+class LoggedCommand extends LoggedQuery {
 
     public $query;
 


### PR DESCRIPTION
Correct errors for CakePHP version 3.5, when debug is active : 
 Argument 1 passed to DebugKit\\Database\\Log\\DebugLog::log() must be an instance of Cake\\Database\\Log\\LoggedQuery, instance of Cake\\Redis\\LoggedCommand given, called in \/app\/vendor\/lorenzo\/redis\/src\/RedisConnection.php on line 183 in \/app\/vendor\/cakephp\/debug_kit\/src\/Database\/Log\/DebugLog.php on 146