### PR TITLE
Added functions to make debugKit work on cake > 3.7 env

### DIFF
--- a/src/RedisConnection.php
+++ b/src/RedisConnection.php
@@ -137,6 +137,47 @@ class RedisConnection implements ConnectionInterface, DriverInterface
     /**
      * {@inheritDoc}
      */
+    public function getLogger($instance = null)
+    {
+        if ($instance === null) {
+            if ($this->_logger === null) {
+                $this->_logger = new RedisLogger();
+            }
+            return $this->_logger;
+        }
+        $this->_logger = $instance;
+        return $this->_logger;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isQueryLoggingEnabled()
+    {
+        return $this->_logQueries;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function enableQueryLogging()
+    {
+        $this->_logQueries = true;
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function disableQueryLogging()
+    {
+        $this->_logQueries = false;
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function transactional(callable $operation)
     {
         return $this->driver()->transactional($operation);


### PR DESCRIPTION
Hi Lorenzo.

We been using your adapter for a while on cake 3.4 and now that we upgraded to 3.8 we found a missing function error while using debugKit.

 Call to undefined method Cake\Redis\Driver\PHPRedisDriver::isQueryLoggingEnabled()

With this the error goes away.

Regards