### PR TITLE
Relaxed cakephp version >= 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "CakePHP support for the Redis key-value database",
     "type": "cakephp-plugin",
     "require": {
-        "cakephp/datasource": "4.2.x",
-        "cakephp/database": "4.2.x"
+        "cakephp/datasource": "^4.2",
+        "cakephp/database": "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "@stable",


### PR DESCRIPTION
We are migrating to Cakephp 4.3 and the 4.2.x version constraint is blocking us.